### PR TITLE
"glance help FOO" is now case insensitive

### DIFF
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1455,8 +1455,8 @@ glance inspectStats A.hdf
         if command is None: 
             print_all_summary = True
         else:
-            if command in commands :
-                print commands[command].__doc__
+            if (command.lower() in lower_locals):
+                print lower_locals[command.lower()].__doc__
             else :
                 print_all_summary = True
 


### PR DESCRIPTION
Command names are case insensitive.  "glance reportGen" and "glance reportgen" are synonymous.

However, help requests remain case sensitive. "glance help reportgen" fails.  This patch makes it case insensitive.
