### PR TITLE
glance --version now returns 0

### DIFF
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1478,9 +1478,10 @@ glance inspectStats A.hdf
 
     # if what the user asked for is not one of our existing functions, print the help
     if ((not args) or (args[0].lower() not in lower_locals)):
-        if not options.version :
-            parser.print_help()
-            help()
+        if options.version:
+            return 0;
+        parser.print_help()
+        help()
         return 9
     else:
         # call the function the user named, given the arguments from the command line, lowercase the request to ignore case


### PR DESCRIPTION
Previously "glance --version" was treated as an error, and the process's exit code was "9".  Displaying the version isn't an error.
