### PR TITLE
Sort variables in output from stats & inspectStats.

### DIFF
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1023,8 +1023,10 @@ def stats_library_call(afn, bfn, var_list=[ ],
     LOG.debug(str(names))
     doc_each  = do_document and len(names)==1
     doc_atend = do_document and len(names)!=1
-    
-    for name, epsilon, missing in names:
+
+    sorted_names = sorted(names, None, lambda X:X[0]);
+
+    for name, epsilon, missing in sorted_names:
         
         # make sure that it's possible to load this variable
         if not(aFile.is_loadable_type(name)) or not(bFile.is_loadable_type(name)) :
@@ -1102,8 +1104,10 @@ def inspect_stats_library_call (afn, var_list=[ ], options_set={ }, do_document=
     LOG.debug(str(names))
     doc_each  = do_document and len(names)==1
     doc_atend = do_document and len(names)!=1
+
+    sorted_names = sorted(names, None, lambda X:X[0]);
     
-    for name, epsilon, missing in names:
+    for name, epsilon, missing in sorted_names:
         
         # make sure that it's possible to load this variable
         if not(aFile.is_loadable_type(name)) :

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1024,9 +1024,7 @@ def stats_library_call(afn, bfn, var_list=[ ],
     doc_each  = do_document and len(names)==1
     doc_atend = do_document and len(names)!=1
 
-    sorted_names = sorted(names, None, lambda X:X[0]);
-
-    for name, epsilon, missing in sorted_names:
+    for name, epsilon, missing in sorted(names, key=lambda X:X[0]):
         
         # make sure that it's possible to load this variable
         if not(aFile.is_loadable_type(name)) or not(bFile.is_loadable_type(name)) :
@@ -1105,10 +1103,8 @@ def inspect_stats_library_call (afn, var_list=[ ], options_set={ }, do_document=
     doc_each  = do_document and len(names)==1
     doc_atend = do_document and len(names)!=1
 
-    sorted_names = sorted(names, None, lambda X:X[0]);
-    
-    for name, epsilon, missing in sorted_names:
-        
+    for name, epsilon, missing in sorted(names, key=lambda X:X[0]):
+
         # make sure that it's possible to load this variable
         if not(aFile.is_loadable_type(name)) :
             LOG.warn(name + " is of a type that cannot be loaded using current file handling libraries included with Glance." +


### PR DESCRIPTION
Previously output was ordered in whatever order the set happened to offer them in. This was not stable between different Python versions.  Ordered alphabetically(ish) should be more human friendly, and will simplify the tests.
