### PR TITLE
add --parsable, formatting info output for parsing

### DIFF
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1188,7 +1188,10 @@ glance inspectStats A.hdf
             try :
                 lal = list(io.open(fn)())
                 lal.sort()
-                print fn + ': ' + ('\n  ' + ' '*len(fn)).join(lal)
+                if options.parsable_output:
+                    print "".join(map(lambda x: fn+"\t"+x+"\n", lal))
+                else:
+                    print fn + ': ' + ('\n  ' + ' '*len(fn)).join(lal)
             except KeyError :
                 LOG.warn('Unable to open / process file selection: ' + fn)
     

--- a/pyglance/glance/config_organizer.py
+++ b/pyglance/glance/config_organizer.py
@@ -476,6 +476,9 @@ def set_up_command_line_options (parser) :
     parser.add_option('-f', '--fork', dest=DO_MAKE_FORKS_KEY,
                       action="store_true", default=False, help="start multiple processes to create images in parallel")
 
+    parser.add_option('--parsable', dest=PARSABLE_OUTPUT_KEY,
+                      action="store_true", default=False, help="format output to be programmatically parsed. 'info' only")
+
 def convert_options_to_dict (options) :
     """
     convert the command line options structure created in compare.py into a dictionary of values

--- a/pyglance/glance/constants.py
+++ b/pyglance/glance/constants.py
@@ -24,6 +24,7 @@ DO_IMAGES_ONLY_ON_FAIL_KEY = 'only_plot_on_fail'
 USE_NO_LON_OR_LAT_VARS_KEY = 'noLonLatVars'
 SHORT_CIRCUIT_DIFFS_KEY    = 'short_circuit_diffs'
 USE_CUSTOM_PROJ_KEY        = 'use_custom_projection'
+PARSABLE_OUTPUT_KEY        = 'parsable_output'
 
 # constants related to storing information from the run
 


### PR DESCRIPTION
"glance info --parsable" now outputs the results in tab deliminated format, repeating the filename on each line, making it easier to parse programmatically. Additional fields may be added later!

At the moment only supports "info".  May add support for other formats later.
