### PR TITLE
Add data shapes to parsable info output

### DIFF
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1187,10 +1187,15 @@ glance inspectStats A.hdf
         problems = 0
         for fn in args:
             try :
-                lal = list(io.open(fn)())
+                input = io.open(fn)
+                lal = list(input())
                 lal.sort()
                 if options.parsable_output:
-                    print "".join(map(lambda x: fn+"\t"+x+"\n", lal))
+                    def format_parsable(file, input, var):
+                        try: shape = str(input[var].shape)
+                        except ValueError: shape = ""
+                        return file+"\t"+var+"\t"+shape+"\n"
+                    print "".join(map(lambda x: format_parsable(fn, input, x), lal))
                 else:
                     print fn + ': ' + ('\n  ' + ' '*len(fn)).join(lal)
             except KeyError :


### PR DESCRIPTION
With this patch, "git info --parsable" includes the data shapes.

I've wanted this occasionally, particularly when  nosing around files. I expect it to be useful if I get around to writing the test suite.

Example usage:

```
$ bin/glance info --parsable input.nc | column -t
input.nc  Good_Data_Points    (1,)
input.nc  Good_Nav_Points     (1,)
input.nc  Good_Overal_Points  (1,)
input.nc  Projection
input.nc  Total_Points        (1,)
input.nc  brit_val_08bit_b01  (5424,   5424)
input.nc  brit_val_12bit_b01  (5424,   5424)
input.nc  qa_flag_b01         (5424,   5424)
input.nc  rad_b01             (5424,   5424)
input.nc  rad_max             (1,)
input.nc  rad_mean            (1,)
input.nc  rad_min             (1,)
input.nc  rad_stdev           (1,)
input.nc  refl_b01            (5424,   5424)
input.nc  refl_max            (1,)
input.nc  refl_mean           (1,)
input.nc  refl_min            (1,)
input.nc  refl_stdev          (1,)
input.nc  swathtimes          (22,)
input.nc  time                (1,)
input.nc  x                   (5424,)
input.nc  y                   (5424,)
```
