### PR TITLE
Add "--fields" option for glance info

### DIFF
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1135,6 +1135,13 @@ def inspect_stats_library_call (afn, var_list=[ ], options_set={ }, do_document=
         print >> output_channel, ('\n\n' + statistics.INSP_STATISTICS_DOC_STR)
 
 def gather_stats_for_variable(filehandle, variable):
+    """ Generate statistics for a variable, flatting into a single level dictionary
+
+    Generate statistics for the variable variable in the file filehandle.  
+    statistics.StatisticalInspectionAnalysis.withSimpleData normally returns a
+    complex, nested data structure; this method flattens it out to a simple
+    dictionary.
+    """
     missing_val = filehandle.missing_value(variable)
     stats = statistics.StatisticalInspectionAnalysis.withSimpleData(filehandle[variable], missing_val)
     results = {}
@@ -1198,6 +1205,12 @@ def return_info_fields(file, input, var, fields):
 
 
 def info_impl(options, *args):
+    """list information about a list of files
+    List available variables for comparison.
+
+    (Moved out of "info" inside of main as it has gotten
+    decidedly non-trivial. This "impl"ements that function.)
+    """
     problems = 0
 
     fields = options.fields.split(',')

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1304,6 +1304,7 @@ glance inspectStats A.hdf
         --fields   specify one or more fields to print for each variable:
                     filename - The name of the file containing the variable
                     variable - The name of the variable
+                    shape -    The shape of the data
                     <AttributeName> - If the variable has the specified 
                                attribute, it will be printed. ex: FillValue
                     stats(<StatName>) - Any statistic from 

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1136,7 +1136,7 @@ def inspect_stats_library_call (afn, var_list=[ ], options_set={ }, do_document=
 
 def gather_stats_for_variable(filehandle, variable):
     missing_val = filehandle.missing_value(variable)
-    stats = statistics.StatisticalInspectionAnalysis.withSimpleData(filehandle[variable])
+    stats = statistics.StatisticalInspectionAnalysis.withSimpleData(filehandle[variable], missing_val)
     results = {}
     for title, data in stats.dictionary_form().items():
         results.update(data)

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1200,10 +1200,7 @@ def return_info_fields(file, input, var, fields):
 def info_impl(options, *args):
     problems = 0
 
-    fields = []
-    if options.fields is not None:
-        fields = options.fields.split(',')
-    fields = ["filename", "variable", "shape"] + fields
+    fields = options.fields.split(',')
 
     for fn in args:
         try :

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1204,12 +1204,9 @@ def return_info_fields(file, input, var, fields):
     return result
 
 
-def info_impl(options, *args):
+def info_library_call(options, *args):
     """list information about a list of files
     List available variables for comparison.
-
-    (Moved out of "info" inside of main as it has gotten
-    decidedly non-trivial. This "impl"ements that function.)
     """
     problems = 0
 
@@ -1303,7 +1300,7 @@ glance inspectStats A.hdf
         """list information about a list of files
         List available variables for comparison.
         """
-        return info_impl(options, *args)
+        return info_library_call(options, *args)
     
     def stats(*args):
         """create statistics summary of variables

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1297,8 +1297,22 @@ glance inspectStats A.hdf
     """
     
     def info(*args):
-        """list information about a list of files
-        List available variables for comparison.
+        """List information about variables in files
+
+        --parsable prints one variable per line, with field of information
+                   seperated by tabs.
+        --fields   specify one or more fields to print for each variable:
+                    filename - The name of the file containing the variable
+                    variable - The name of the variable
+                    <AttributeName> - If the variable has the specified 
+                               attribute, it will be printed. ex: FillValue
+                    stats(<StatName>) - Any statistic from 
+                               "glance inspectstats"
+                               ex: stats(num_data_points)
+
+        Examples:
+         glance info hdffile
+         glance info hdffile --parsable --fields 'filename,variable,stats(min),FillValue'
         """
         return info_library_call(options, *args)
     

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1187,10 +1187,15 @@ glance inspectStats A.hdf
         problems = 0
         for fn in args:
             try :
-                lal = list(io.open(fn)())
+                input = io.open(fn)
+                lal = list(input())
                 lal.sort()
                 if options.parsable_output:
-                    print "".join(map(lambda x: fn+"\t"+x+"\n", lal))
+                    def format_parsable(file, input, var):
+                        try: shape = str(input[var].shape)
+                        except ValueError: shape = ""
+                        return file+"\t"+var+"\t"+shape+"\n"
+                    print "".join(map(lambda x: format_parsable(fn, input, x), lal))
                 else:
                     print fn + ': ' + ('\n  ' + ' '*len(fn)).join(lal)
             except KeyError :

--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -1157,8 +1157,10 @@ def return_info_fields(file, input, var, fields):
                 result.append(str(input[var].shape))
             except ValueError:
                 result.append(None)
+        elif f in input.get_variable_attributes(var):
+            result.append(input.get_attribute(var, f))
         else:
-            raise Exception('Unknown field "'+f+'" requested.')
+            result.append(None)
     return result
 
 
@@ -1178,7 +1180,7 @@ def info_impl(options, *args):
             if options.parsable_output:
                 def format_parsable(file, input, var):
                     out_fields = return_info_fields(file, input, var, fields)
-                    str_out_fields = [ str(x) for x in out_fields ]
+                    str_out_fields = [ str(x) if x is not None else "" for x in out_fields ]
                     str_out = "\t".join(str_out_fields)+"\n"
                     return str_out
                 print "".join(map(lambda x: format_parsable(fn, input, x), lal))

--- a/pyglance/glance/config_organizer.py
+++ b/pyglance/glance/config_organizer.py
@@ -468,7 +468,8 @@ def set_up_command_line_options (parser) :
     parser.add_option('-c', '--configfile', dest=OPTIONS_CONFIG_FILE_KEY, type='string', default=None,
                       help="set optional configuration file")
     parser.add_option('--fields', type='string',
-                      help='comma separted list of additional fields to add to info --parsable output')
+                      default='filename,variable',
+                      help="comma separted list of additional fields to add to info's output")
     
     # should pass/fail be tested?
     parser.add_option('-x', '--doPassFail', dest=DO_TEST_PASSFAIL_KEY,

--- a/pyglance/glance/config_organizer.py
+++ b/pyglance/glance/config_organizer.py
@@ -469,7 +469,7 @@ def set_up_command_line_options (parser) :
                       help="set optional configuration file")
     parser.add_option('--fields', type='string',
                       default='filename,variable',
-                      help="comma separted list of additional fields to add to info's output")
+                      help="comma separted list of additional fields to add to info's output. Values include filename, variable, <AttributeName> and stats(StatisticName)")
     
     # should pass/fail be tested?
     parser.add_option('-x', '--doPassFail', dest=DO_TEST_PASSFAIL_KEY,

--- a/pyglance/glance/config_organizer.py
+++ b/pyglance/glance/config_organizer.py
@@ -467,6 +467,8 @@ def set_up_command_line_options (parser) :
                       help="generate only html report files (no images)")
     parser.add_option('-c', '--configfile', dest=OPTIONS_CONFIG_FILE_KEY, type='string', default=None,
                       help="set optional configuration file")
+    parser.add_option('--fields', type='string',
+                      help='comma separted list of additional fields to add to info --parsable output')
     
     # should pass/fail be tested?
     parser.add_option('-x', '--doPassFail', dest=DO_TEST_PASSFAIL_KEY,

--- a/pyglance/glance/config_organizer.py
+++ b/pyglance/glance/config_organizer.py
@@ -469,7 +469,7 @@ def set_up_command_line_options (parser) :
                       help="set optional configuration file")
     parser.add_option('--fields', type='string',
                       default='filename,variable',
-                      help="comma separted list of additional fields to add to info's output. Values include filename, variable, <AttributeName> and stats(StatisticName)")
+                      help="comma separted list of additional fields to add to info's output. Values include filename, variable, shape, <AttributeName> and stats(StatisticName)")
     
     # should pass/fail be tested?
     parser.add_option('-x', '--doPassFail', dest=DO_TEST_PASSFAIL_KEY,


### PR DESCRIPTION
--fields is a comma seperated list of fields to be output. By default, it's "filename,variable", which is the old output.  You can use any of:

- filename
- variable
- shape - data shape of the variable
- _ATTRIBUTE_NAME_ - any attribute associated with the variable. If missing, will be an empty string.
- stats(_STAT_NAME_) - any statistic as seen in glance inspectStats. The names are exactly as shown there, so "stats(min)" and "stats(finite_count)" are options.

I'd regularly wanted "shape" and the attribute "long_name" for use while exploring new data. A need to create a report of all of our output data drove generalizing the problem and adding stats(STAT_NAME).

This includes and completely replaces pull request #12