### PR TITLE
Statistics now work on scalar values (0d arrays)

### DIFF
--- a/pyglance/glance/data.py
+++ b/pyglance/glance/data.py
@@ -160,6 +160,23 @@ class DataObject (object) :
         
         return DataObject(self.data.copy(), fillValue=self.fill_value, ignoreMask=self.masks.ignore_mask,
                  overrideFillValue=self.override_fill_value, defaultFillValue=self.default_fill_value)
+
+    def holding_array(self):
+        """
+        Return a version of myself where self.data is always an array.
+
+        Suitable for code paths that insist on an array. 
+
+        If self.data is already an array, returns self.
+        If self.data is a simple scalar, copies myself, changing the copy's
+        self.data to be an array with a single value, and return the copy.
+        """
+        if len(self.data.shape) != 0:
+            return self
+        copy = self.copy()
+        copy.data = np.array([self.data.item()])
+        copy.self_analysis()
+        return copy
     
     def self_analysis(self, re_do_analysis=False) :
         """

--- a/pyglance/glance/stats.py
+++ b/pyglance/glance/stats.py
@@ -1064,6 +1064,8 @@ class StatisticalInspectionAnalysis (StatisticalData) :
         """
         build and set all of the statistics sets
         """
+
+        dataObject = dataObject.holding_array()
         
         self.general      = GeneralStatistics(     dataObject=dataObject,
                                                            doExtras=True)


### PR DESCRIPTION
For variables who shape is "0" (that is, a simple scalar value), statistics calculations now work.  Although many of the statistics are silly, this is useful for report generation.

Implementation: DataObject has a new function "holding_array" which in most cases returns itself. But if self.data.shape==0, it returns a copy of itself with self.data's scalar value tossed into a single element array.  Now that the data is an array, as expected, the statistics code works fine.