### PR TITLE
Keep going if reportGen encounters a string variable

### DIFF
--- a/pyglance/glance/load.py
+++ b/pyglance/glance/load.py
@@ -224,6 +224,9 @@ def open_and_process_files (fileNames):
     
     return files
 
+class ValueErrorStringToFloat(Exception):
+    pass
+
 def load_variable_data(fileObject, variableNameInFile,
                        forceDType=None,
                        dataFilter=None,
@@ -252,6 +255,8 @@ def load_variable_data(fileObject, variableNameInFile,
             variableData = numpy.array(fileObject[variableNameInFile]) if forceDType is None else numpy.array(fileObject[variableNameInFile], dtype=forceDType)
             variableData = variableData.astype(numpy.uint8) if correctForAWIPS else variableData
         except Exception, ex :
+            if type(ex) is ValueError and str(ex) == "could not convert string to float: ":
+                raise ValueErrorStringToFloat(str(ex))
             import traceback
             exceptionToRaise = ValueError('Unable to retrieve ' + variableNameInFile + ' data. The variable name' + 
                       ' may not exist in this file or an error may have occured while attempting to' +


### PR DESCRIPTION
Old behavior was to raise an uncaught exception. Now it reports a warning and continues onward.

The change is actually pretty small, but I had to increase the indent level of a large block to put a try/except around it. Here's the full diff ignoring whitespace changes (Courtesy of git diff -w master..reportgen-strings )
```
diff --git a/pyglance/glance/compare.py b/pyglance/glance/compare.py
index 7567dec..3e0f4a1 100644
--- a/pyglance/glance/compare.py
+++ b/pyglance/glance/compare.py
@@ -37,7 +37,7 @@ import glance.collocation   as collocation
 import glance.config_organizer as config_organizer
 
 from glance.util        import clean_path, rsync_or_copy_files, get_glance_version_string, get_run_identification_info, setup_dir_if_needed
-from glance.load        import get_UV_info_from_magnitude_direction_info, load_variable_data, open_and_process_files, handle_lon_lat_info, handle_lon_lat_info_for_one_file
+from glance.load        import get_UV_info_from_magnitude_direction_info, load_variable_data, open_and_process_files, handle_lon_lat_info, handle_lon_lat_info_for_one_file, ValueErrorStringToFloat
 from glance.lonlat_util import VariableComparisonError
 from glance.constants   import *
 from glance.gui_constants import A_CONST, B_CONST
@@ -740,7 +740,7 @@ def reportGen_library_call (a_path, b_path, var_list=[ ],
     # go through each of the possible variables in our files
     # and make a report section with images for whichever ones we can
     for displayName in finalNames:
-        
+        try:
             # pull out the information for this variable analysis run
             varRunInfo = finalNames[displayName].copy()
             
@@ -959,6 +959,8 @@ def reportGen_library_call (a_path, b_path, var_list=[ ],
                          + 'longitude ' + str(good_shape_from_lon_lat) + ' and '
                          + 'latitude '  + str(good_shape_from_lon_lat) + ' variables.')
                 LOG.warn(message)
+        except ValueErrorStringToFloat as e:
+            LOG.warn("Unable to compare "+displayName+": "+str(e))
 
     # the end of the loop to examine all the variables
     
diff --git a/pyglance/glance/load.py b/pyglance/glance/load.py
index 58b6962..5ac4e25 100644
--- a/pyglance/glance/load.py
+++ b/pyglance/glance/load.py
@@ -224,6 +224,9 @@ def open_and_process_files (fileNames):
     
     return files
 
+class ValueErrorStringToFloat(Exception):
+    pass
+
 def load_variable_data(fileObject, variableNameInFile,
                        forceDType=None,
                        dataFilter=None,
@@ -252,6 +255,8 @@ def load_variable_data(fileObject, variableNameInFile,
             variableData = numpy.array(fileObject[variableNameInFile]) if forceDType is None else numpy.array(fileObject[variableNameInFile], dtype=forceDType)
             variableData = variableData.astype(numpy.uint8) if correctForAWIPS else variableData
         except Exception, ex :
+            if type(ex) is ValueError and str(ex) == "could not convert string to float: ":
+                raise ValueErrorStringToFloat(str(ex))
             import traceback
             exceptionToRaise = ValueError('Unable to retrieve ' + variableNameInFile + ' data. The variable name' + 
                       ' may not exist in this file or an error may have occured while attempting to' +
```