### PR TITLE
Raise built-in open exceptions if file inaccessible

### DIFF
--- a/pyglance/glance/io.py
+++ b/pyglance/glance/io.py
@@ -1355,6 +1355,13 @@ class jpss_adl(object):
 
 def open(pathname, allowWrite=False):
     suffix = os.path.splitext(pathname)[1][1:].lower()
+
+    # Just test we can open the file so we automatically raise a suitable
+    # error if we can't access it.
+    from __builtin__ import open
+    with open(pathname):
+        pass
+
     if (not suffix) or (suffix not in globals()):
         # this ican be used to specify a format on the command line by setting the
         # environment variable FORMAT, for example:


### PR DESCRIPTION
If the file is inaccessible, raise the same Exception the built-in global open() would.  This makes for more specific and helpful errors.

This is done by doing an experimental `open` on the file and not catching anything.

I decided against using `os.access` and `os.file.isfile`; the former is incorrect on some filesystems, like Lustre, the latter just requires a lot of additional code to raise the correct exception.

Before:

<pre>
$ glance stats directory directory
Traceback (most recent call last):
  File "/home/adesmet/bin/glance", line 9, in <module>
    load_entry_point('uwglance', 'console_scripts', 'glance')()
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1504, in main
    rc = lower_locals[args[0].lower()](*args[1:])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1241, in stats
    output_channel=toPrintTo)
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1011, in stats_library_call
    filesInfo = open_and_process_files([afn, bfn])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/load.py", line 217, in open_and_process_files
    tempFileObject = (io.open(fileName))
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/io.py", line 1364, in open
    cls = globals()[suffix]
<b>KeyError: None</b>
$ glance stats unreadable unreadable 
Traceback (most recent call last):
  File "/home/adesmet/bin/glance", line 9, in <module>
    load_entry_point('uwglance', 'console_scripts', 'glance')()
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1504, in main
    rc = lower_locals[args[0].lower()](*args[1:])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1241, in stats
    output_channel=toPrintTo)
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1011, in stats_library_call
    filesInfo = open_and_process_files([afn, bfn])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/load.py", line 217, in open_and_process_files
    tempFileObject = (io.open(fileName))
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/io.py", line 1364, in open
    cls = globals()[suffix]
<b>KeyError: None</b>
</pre>

After:

<pre>
$ glance stats directory directory
Traceback (most recent call last):
  File "/home/adesmet/bin/glance", line 9, in <module>
    load_entry_point('uwglance', 'console_scripts', 'glance')()
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1504, in main
    rc = lower_locals[args[0].lower()](*args[1:])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1241, in stats
    output_channel=toPrintTo)
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1011, in stats_library_call
    filesInfo = open_and_process_files([afn, bfn])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/load.py", line 217, in open_and_process_files
    tempFileObject = (io.open(fileName))
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/io.py", line 1362, in open
    with open(pathname):
<b>IOError: [Errno 21] Is a directory: '/home/adesmet/src/glance/test-cases/directory'</b>
$ glance stats unreadable unreadable 
Traceback (most recent call last):
  File "/home/adesmet/bin/glance", line 9, in <module>
    load_entry_point('uwglance', 'console_scripts', 'glance')()
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1504, in main
    rc = lower_locals[args[0].lower()](*args[1:])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1241, in stats
    output_channel=toPrintTo)
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/compare.py", line 1011, in stats_library_call
    filesInfo = open_and_process_files([afn, bfn])
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/load.py", line 217, in open_and_process_files
    tempFileObject = (io.open(fileName))
  File "/home/adesmet/src/glance/uwglance/pyglance/glance/io.py", line 1362, in open
    with open(pathname):
<b>IOError: [Errno 13] Permission denied: '/home/adesmet/src/glance/test-cases/unreadable'</b>
</pre>
