### PR TITLE
Smart GUI variable selection

### DIFF
--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -252,7 +252,7 @@ class GlanceGUIView (QtGui.QWidget) :
         variableSelection = QtGui.QComboBox()
         variableSelection.setDisabled(True)
         variableSelection.currentIndexChanged.connect(partial(self.reportVariableSelected, file_prefix=file_prefix))
-        variableSelection.lastSelected = None
+        variableSelection.lastSelected = "InvalidStringThatShouldNeverExist"
         self.widgetInfo[file_prefix]['variable'] = variableSelection
         grid_layout.addWidget(variableSelection, currentRow, 2, 1, 3)
         
@@ -891,13 +891,32 @@ class GlanceGUIView (QtGui.QWidget) :
         
         # if we got a new variable list, set up the appropriate drop down list
         if variable_list is not None :
+            # Cache now, because clear/addItems will change it as a side effect
+            last_selected = self.widgetInfo[file_prefix]['variable'].lastSelected
+
             # set up the list of selectable variables for analysis
             self.widgetInfo[file_prefix]['variable'].clear()
             self.widgetInfo[file_prefix]['variable'].addItems(variable_list)
+
+            # If the new file has the same variable name we were just
+            # displaying, default to it.
+            i = self.widgetInfo[file_prefix]['variable'].findText(last_selected)
+            if i != -1:
+                selected_variable = last_selected
+            else:
+                # That didn't work? Well, can we find a variable name
+                # matching what the other field is displaying?
+                if file_prefix == A_CONST: other = B_CONST
+                else:                      other = A_CONST
+                other_string = self.widgetInfo[other]['variable'].currentText()
+                i = self.widgetInfo[file_prefix]['variable'].findText(other_string)
+                if i != -1:
+                    selected_variable = last_selected
         
         # set the selected variable
         tempPosition = self.widgetInfo[file_prefix]['variable'].findText(selected_variable)
         self.widgetInfo[file_prefix]['variable'].setCurrentIndex(tempPosition)
+        self.widgetInfo[file_prefix]['variable'].lastSelected = selected_variable
         
         # set the override
         self.widgetInfo[file_prefix]['override'].setChecked(use_fill_override)


### PR DESCRIPTION
Try to automatically pick the "right" variable when loading a file or changing a variable in the GUI.

This should slightly speed up interactive use of the GUI, as the default selected variable is more likely to be the one the user is interested in.

If the user changes the A variable, and the A and B variables were the same, try to change the B variable to match. (Changing B does not change A so that the user has a way to desynchronize them if necessary.)

If the user loads a new file, try to select the same variable name that was selected for the previous file. If that doesn't work, check the current variable selected for the other "slot" (A or B) and see if it's present in the new file; if it is, select it.  Otherwise stick with the default: select the first variable.