### PR TITLE
Tighten up the GUI layout, 

### DIFF
--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -178,6 +178,9 @@ class GlanceGUIView (QtGui.QWidget) :
         # All relevant fields include column 2, so make it stretchable
         # (and by implication, make the rest non-stretchable)
         layoutToUse.setColumnStretch(2,1)
+        # Also column 3, mostly so "Display Plot" stretches as it's the
+        # most important button
+        layoutToUse.setColumnStretch(3,1)
         
         # set up the file info for the A file
         currentRow = self._add_file_related_controls(A_CONST, layoutToUse, currentRow)

--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -162,6 +162,10 @@ class GlanceGUIView (QtGui.QWidget) :
         # create the layout and set up some of the overall record keeping
         layoutToUse = QtGui.QGridLayout()
         currentRow = 0
+
+        # All relevant fields include column 2, so make it stretchable
+        # (and by implication, make the rest non-stretchable)
+        layoutToUse.setColumnStretch(2,1)
         
         # set up the file info for the A file
         currentRow = self._add_file_related_controls(A_CONST, layoutToUse, currentRow)

--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -404,6 +404,8 @@ class GlanceGUIView (QtGui.QWidget) :
         # create the layout and set up some of the overall record keeping
         layoutToUse = QtGui.QGridLayout()
         currentRow = 0
+
+        layoutToUse.setColumnMinimumWidth(0,20)
         
         # add the filtering related controls
         currentRow = self._add_simple_filter_controls(A_CONST, layoutToUse, currentRow)
@@ -426,7 +428,7 @@ class GlanceGUIView (QtGui.QWidget) :
         tempLabel = QtGui.QLabel(str(file_prefix) + " simple filtering:")
         #tempLabel.setToolTip("Simple filters are applied after any complex filters are resolved.") # TODO need to specify this once there are complex filters
         tempLabel.setToolTip("Simple filters that will be applied to the data before display or analysis.")
-        grid_layout.addWidget(tempLabel, current_row, 0)
+        grid_layout.addWidget(tempLabel, current_row, 0, 1, 2)
         
         current_row += 1
         

--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -317,6 +317,9 @@ class GlanceGUIView (QtGui.QWidget) :
         # create the layout and set up some of the overall record keeping
         layoutToUse = QtGui.QGridLayout()
         currentRow = 0
+
+        # Only allow column 2 to stretch.
+        layoutToUse.setColumnStretch(2,1)
         
         # add the drop down for selecting a custom color map
         layoutToUse.addWidget(QtGui.QLabel("Color map:"), currentRow, 0)

--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -27,6 +27,18 @@ The GUI's most complex responsibility is keeping the user from entering
 garbage data into the UI.
 """
 
+def add_filler_row(layout):
+    """
+    Add a stretchable dummy row to the bottom of a QGridLayout.
+
+    So long as no other rows are set stretchable, this will use
+    up all "extra" space, keeping the other rows compact.
+    """
+    row = layout.rowCount()
+    layout.addWidget(QtGui.QLabel(""), row, 0)
+    layout.setRowStretch(row, 1)
+
+
 class _DoubleOrNoneValidator (QtGui.QDoubleValidator) :
     """
     This validator accepts doubles like it's parent class or None.
@@ -378,6 +390,9 @@ class GlanceGUIView (QtGui.QWidget) :
         # add the lon/lat controls that are separated by file
         currentRow = self._add_lon_lat_controls(A_CONST, layoutToUse, currentRow)
         currentRow = self._add_lon_lat_controls(B_CONST, layoutToUse, currentRow)
+
+        add_filler_row(layoutToUse)
+        currentRow += 1
         
         return layoutToUse
     
@@ -393,6 +408,9 @@ class GlanceGUIView (QtGui.QWidget) :
         # add the filtering related controls
         currentRow = self._add_simple_filter_controls(A_CONST, layoutToUse, currentRow)
         currentRow = self._add_simple_filter_controls(B_CONST, layoutToUse, currentRow)
+
+        add_filler_row(layoutToUse)
+        currentRow += 1
         
         return layoutToUse
     

--- a/pyglance/glance/gui_view.py
+++ b/pyglance/glance/gui_view.py
@@ -483,7 +483,7 @@ class GlanceGUIView (QtGui.QWidget) :
         latNameDropDown = QtGui.QComboBox()
         latNameDropDown.activated.connect(partial(self.reportLatitudeSelected, file_prefix=file_prefix))
         self.widgetInfo[file_prefix]["latName"] = latNameDropDown
-        grid_layout.addWidget(latNameDropDown, current_row, 2, 1, 2)
+        grid_layout.addWidget(latNameDropDown, current_row, 2)
         
         current_row += 1
         
@@ -492,7 +492,7 @@ class GlanceGUIView (QtGui.QWidget) :
         lonNameDropDown = QtGui.QComboBox()
         lonNameDropDown.activated.connect(partial(self.reportLongitudeSelected, file_prefix=file_prefix))
         self.widgetInfo[file_prefix]["lonName"] = lonNameDropDown
-        grid_layout.addWidget(lonNameDropDown, current_row, 2, 1, 2)
+        grid_layout.addWidget(lonNameDropDown, current_row, 2)
         
         current_row += 1
         


### PR DESCRIPTION
Tighten up the GUI layout:

- Only columns that make sense to stretch are allowed to stretch.
- Short tables (settings and filters) are compacted to the top.
- The section labels on the filters tab now overhang their settings, instead of being next to them.

Before|After
------|-----
<img src="https://cloud.githubusercontent.com/assets/20426375/23924092/5af3dcf2-08d7-11e7-90e8-0c5e094884e3.png" width="300">|<img src="https://cloud.githubusercontent.com/assets/20426375/23924093/5af582f0-08d7-11e7-98ec-32f5f26d6d62.png" width="300">
<img src="https://cloud.githubusercontent.com/assets/20426375/23924091/5af2167e-08d7-11e7-8697-8e897bb293f7.png" width="300">|<img src="https://cloud.githubusercontent.com/assets/20426375/23924090/5ae11022-08d7-11e7-8d55-8218b869e0ed.png" width="300">
