### PR TITLE
Fix masks when turning scalar into 1d array

### DIFF
--- a/pyglance/glance/data.py
+++ b/pyglance/glance/data.py
@@ -175,7 +175,13 @@ class DataObject (object) :
             return self
         copy = self.copy()
         copy.data = np.array([self.data.item()])
-        copy.self_analysis()
+
+        ignore_mask = None
+        if copy.masks.ignore_mask is not None:
+            ignore_mask = np.array([copy.masks.ignore_mask.item()])
+        copy.masks      = BasicMaskSetObject(ignore_mask)
+
+        copy.self_analysis(re_do_analysis=True)
         return copy
     
     def self_analysis(self, re_do_analysis=False) :


### PR DESCRIPTION
If the scalar DataObject had an ignore mask, the self_analysis got grumpy when tried to use a scalar mask on top of a 1d array.  This recreates the mask in 1d if necessary, and wipes the remaining masks.

Fixes bug introduced in d8bf973beefd1b0056d6637eb93b3cd79bb2223a (scalar-stats branch)